### PR TITLE
feat: Implement Native Repost Rendering in Feed UI

### DIFF
--- a/components/ui/posts/feed-item-router.tsx
+++ b/components/ui/posts/feed-item-router.tsx
@@ -2,6 +2,7 @@ import { FeedPost } from "@/services/feedApi";
 import React from "react";
 import ForYouCard from "./for-you-card";
 import ListeningSessionPost from "./listening-session-post";
+import RepostPost from "./repost-post";
 import SharedAlbumPost from "./shared-album-post";
 import SharedArtistPost from "./shared-artist-post";
 import SharedPlaylistPost from "./shared-playlist-post";
@@ -26,6 +27,8 @@ export default function FeedItemRouter({ item, onDelete }: FeedItemRouterProps) 
       return <SharedArtistPost item={item as FeedPost} onDelete={onDelete} />;
     case "ListeningSession":
       return <ListeningSessionPost item={item as FeedPost} onDelete={onDelete} />;
+    case "Repost":
+      return <RepostPost item={item as FeedPost} onDelete={onDelete} />;
     default:
       return null;
   }

--- a/components/ui/posts/repost-post.tsx
+++ b/components/ui/posts/repost-post.tsx
@@ -1,0 +1,182 @@
+import { ThemedText } from "@/components/ui/themed-text";
+import { Colors } from "@/constants/theme";
+import { useTheme } from "@/contexts/ThemeContext";
+import feedApi, { FeedPost } from "@/services/feedApi";
+import { MaterialIcons } from "@expo/vector-icons";
+import { Image } from "expo-image";
+import { router } from "expo-router";
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import PostHeader from "./post-header";
+
+interface RepostPostProps {
+  item: FeedPost;
+  onDelete?: (postId: number) => void;
+}
+
+/**
+ * Renders a reposted post. Shows a "reposted by [user]" banner,
+ * then the original post content nested inside a card.
+ */
+export default function RepostPost({ item, onDelete }: RepostPostProps) {
+  const { colors } = useTheme();
+
+  const timeAgo = feedApi.getTimeAgo(item.createdAt);
+  const originalUser = item.originalPostUser;
+
+  // Determine what content the original post had
+  const track = item.track;
+  const album = item.album;
+  const playlist = item.playlist;
+  const artist = item.artist;
+
+  const getContentNavigation = () => {
+    if (track) return () => router.push(`/song/${track.id}`);
+    if (album) return () => router.push(`/album/${album.spotifyId}` as any);
+    if (playlist) return () => router.push(`/playlist/${playlist.spotifyId}` as any);
+    if (artist) return () => router.push(`/artist/${artist.spotifyId}`);
+    return undefined;
+  };
+
+  const handlePress = getContentNavigation();
+
+  const getImageUrl = (): string | null => {
+    if (track?.albumImageUrl) return track.albumImageUrl;
+    if (album?.imageUrl) return album.imageUrl;
+    if (playlist?.imageUrl) return playlist.imageUrl;
+    if (artist?.imageUrl) return artist.imageUrl;
+    return null;
+  };
+
+  const getContentTitle = (): string => {
+    if (track) return track.name || "Unknown Track";
+    if (album) return album.name || "Unknown Album";
+    if (playlist) return playlist.name || "Unknown Playlist";
+    if (artist) return artist.name || "Unknown Artist";
+    return "Unknown";
+  };
+
+  const getContentSubtitle = (): string | null => {
+    if (track) return track.artistNames.join(", ") || null;
+    if (album) return "Album";
+    if (playlist) return "Playlist";
+    if (artist) return "Artist";
+    return null;
+  };
+
+  const imageUrl = getImageUrl();
+
+  return (
+    <View style={styles.container}>
+      {/* Repost banner */}
+      <Pressable
+        style={styles.repostBanner}
+        onPress={() => router.push(`/profile/${item.user.id}`)}
+      >
+        <MaterialIcons name="repeat" size={14} color={Colors.primary} />
+        <ThemedText style={[styles.repostText, { color: colors.text }]}>
+          {item.user.displayName || item.user.handle} reposted
+        </ThemedText>
+      </Pressable>
+
+      {/* Original post content */}
+      <Pressable onPress={handlePress}>
+        {/* Original poster header — use originalPostUser for the header, 
+            but like/repost interactions target the original post */}
+        {originalUser && (
+          <PostHeader
+            user={originalUser}
+            timeAgo={timeAgo}
+            postId={item.originalPostId ?? undefined}
+            onDelete={undefined}
+            initialLiked={item.isLiked}
+            initialLikeCount={item.likeCount}
+            initialReposted={item.isReposted}
+            initialRepostCount={item.repostCount}
+          />
+        )}
+
+        {/* Content card */}
+        <View style={styles.centerContainer}>
+          <View style={[styles.card, { backgroundColor: colors.card }]}>
+            {imageUrl && (
+              <Image
+                source={{ uri: imageUrl }}
+                style={artist ? styles.artistImage : styles.cardImage}
+                contentFit="cover"
+                transition={200}
+              />
+            )}
+            <View style={[styles.cardContent, { backgroundColor: colors.card }]}>
+              <ThemedText
+                style={[styles.cardTitle, { color: colors.text }]}
+                numberOfLines={2}
+              >
+                {getContentTitle()}
+              </ThemedText>
+              {getContentSubtitle() && (
+                <ThemedText
+                  style={[styles.cardSubtitle, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  {getContentSubtitle()}
+                </ThemedText>
+              )}
+            </View>
+          </View>
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {},
+  repostBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 8,
+    paddingHorizontal: 4,
+  },
+  repostText: {
+    fontSize: 12,
+    fontWeight: "600",
+    opacity: 0.6,
+  },
+  centerContainer: {
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+  card: {
+    width: "100%",
+    borderRadius: 16,
+    overflow: "hidden",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.3,
+    shadowRadius: 12,
+    elevation: 8,
+  },
+  cardImage: {
+    width: "100%",
+    aspectRatio: 1,
+  },
+  artistImage: {
+    width: "100%",
+    aspectRatio: 1.2,
+  },
+  cardContent: {
+    padding: 16,
+    justifyContent: "flex-end",
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  cardSubtitle: {
+    fontSize: 14,
+    opacity: 0.6,
+  },
+});

--- a/services/feedApi.ts
+++ b/services/feedApi.ts
@@ -197,6 +197,12 @@ class FeedApiService {
         return `${userName} shared the playlist "${post.playlist?.name}"`;
       case "SharedArtist":
         return `${userName} shared ${post.artist?.name}`;
+      case "Repost":
+        const originalName =
+          post.originalPostUser?.displayName ||
+          post.originalPostUser?.handle ||
+          "someone";
+        return `${userName} reposted ${originalName}'s post`;
       default:
         return `${userName} shared something`;
     }


### PR DESCRIPTION
## Summary

Implements the frontend UI for native repost functionality, completing Issue #36.

### Changes

**New Component: `RepostPost`** (`components/ui/posts/repost-post.tsx`)
- Renders a "🔁 [user] reposted" banner at the top with the reposter's name
- Displays the original poster's info via `PostHeader` (with like/repost interaction buttons)
- Shows the original content (track, album, playlist, or artist) in a styled content card
- Navigates to the appropriate detail page on press

**Updated: `FeedItemRouter`** (`components/ui/posts/feed-item-router.tsx`)
- Added `Repost` case to route repost posts to the new `RepostPost` component

**Updated: `feedApi.ts`** (`services/feedApi.ts`)
- Added `Repost` case to `getPostDescription()` — returns "[user] reposted [original user]'s post"

### Context

The backend already fully supports reposts:
- `PostType.Repost` enum value exists in `Post.cs`
- `PostInteractionController` has `POST/DELETE /api/post/{postId}/repost` endpoints
- `FeedController` includes `originalPostId`, `originalPostUser`, `repostCount`, `isReposted` in feed DTOs
- `PostHeader` already renders animated repost buttons with optimistic updates
- `feedApi.ts` already has `repostPost()`, `removeRepost()`, and batch status methods

The only gap was the frontend rendering — reposts fell through to `default: return null` in `FeedItemRouter`. This PR closes that gap.

Closes #36