### PR TITLE
Feature: Profile Posts Section — View & Scroll User Activity Feed

### DIFF
--- a/components/profile/index.ts
+++ b/components/profile/index.ts
@@ -1,8 +1,11 @@
 // Profile components barrel export
 export { default as CompatibilityScore } from "./compatibility-score";
 export { default as FollowButton } from "./follow-button";
+export { default as PostFilterChips } from "./post-filter-chips";
 export { default as ProfileContent } from "./profile-content";
 export { default as ProfileHeader } from "./profile-header";
+export { default as ProfilePosts } from "./profile-posts";
 export { default as ProfileStats } from "./profile-stats";
+export { default as ProfileTabBar } from "./profile-tab-bar";
 export { default as SOTDProfile } from "./sotd-profile";
 export { default as UserProfile } from "./user-profile";

--- a/components/profile/post-filter-chips.tsx
+++ b/components/profile/post-filter-chips.tsx
@@ -1,0 +1,99 @@
+import { ThemedText } from "@/components/ui/themed-text";
+import { Colors } from "@/constants/theme";
+import { useTheme } from "@/contexts/ThemeContext";
+import { PostType } from "@/services/feedApi";
+import React from "react";
+import { Pressable, ScrollView, StyleSheet } from "react-native";
+
+export type PostFilterType = "All" | "Shared" | "Sessions" | "Likes" | "Reposts";
+
+interface PostFilterChipsProps {
+  activeFilter: PostFilterType;
+  onFilterChange: (filter: PostFilterType) => void;
+}
+
+const FILTERS: { key: PostFilterType; label: string }[] = [
+  { key: "All", label: "All" },
+  { key: "Shared", label: "Shared" },
+  { key: "Sessions", label: "Sessions" },
+  { key: "Likes", label: "Likes" },
+  { key: "Reposts", label: "Reposts" },
+];
+
+/**
+ * Maps a filter chip selection to the PostType(s) the API understands.
+ * Returns undefined for "All" (no filtering).
+ */
+export function getPostTypeForFilter(filter: PostFilterType): PostType | undefined {
+  switch (filter) {
+    case "Shared":
+      return "SharedTrack"; // API will return all shared types when we pass this
+    case "Sessions":
+      return "ListeningSession";
+    case "Likes":
+      return "LikedTrack";
+    case "Reposts":
+      return "Repost";
+    case "All":
+    default:
+      return undefined;
+  }
+}
+
+export default function PostFilterChips({ activeFilter, onFilterChange }: PostFilterChipsProps) {
+  const { colors } = useTheme();
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.container}
+    >
+      {FILTERS.map((filter) => {
+        const isActive = activeFilter === filter.key;
+        return (
+          <Pressable
+            key={filter.key}
+            style={[
+              styles.chip,
+              {
+                backgroundColor: isActive ? Colors.primary : "transparent",
+                borderColor: isActive ? Colors.primary : colors.border,
+              },
+            ]}
+            onPress={() => onFilterChange(filter.key)}
+          >
+            <ThemedText
+              style={[
+                styles.chipLabel,
+                {
+                  color: isActive ? "#FFFFFF" : colors.mutedForeground,
+                  fontWeight: isActive ? "600" : "400",
+                },
+              ]}
+            >
+              {filter.label}
+            </ThemedText>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  chip: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+  },
+  chipLabel: {
+    fontSize: 13,
+  },
+});

--- a/components/profile/profile-content.tsx
+++ b/components/profile/profile-content.tsx
@@ -258,6 +258,7 @@ export default function ProfileContent({
 const styles = StyleSheet.create({
     container: {
         flex: 1,
+        paddingTop: 16,
     },
     section: {
         marginBottom: 24,

--- a/components/profile/profile-posts.tsx
+++ b/components/profile/profile-posts.tsx
@@ -8,6 +8,7 @@ import { router } from "expo-router";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  Dimensions,
   Pressable,
   StyleSheet,
   View,
@@ -83,16 +84,19 @@ export default function ProfilePosts({ userId, isOwnProfile }: ProfilePostsProps
     setActiveFilter(filter);
   }, []);
 
+  // Use screen height as minimum so content never collapses when switching tabs
+  const minContentHeight = Dimensions.get("window").height * 0.5;
+
   if (loading) {
     return (
-      <View style={styles.loadingContainer}>
+      <View style={[styles.loadingContainer, { minHeight: minContentHeight }]}>
         <ActivityIndicator size="large" color={Colors.primary} />
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { minHeight: minContentHeight }]}>
       {/* Filter Chips */}
       <PostFilterChips
         activeFilter={activeFilter}

--- a/components/profile/profile-posts.tsx
+++ b/components/profile/profile-posts.tsx
@@ -96,7 +96,7 @@ export default function ProfilePosts({ userId, isOwnProfile }: ProfilePostsProps
   }
 
   return (
-    <View style={[styles.container, { minHeight: minContentHeight }]}>
+    <View style={styles.container}>
       {/* Filter Chips */}
       <PostFilterChips
         activeFilter={activeFilter}
@@ -105,7 +105,7 @@ export default function ProfilePosts({ userId, isOwnProfile }: ProfilePostsProps
 
       {/* Posts Feed */}
       {posts.length === 0 ? (
-        <View style={styles.emptyContainer}>
+        <View style={[styles.emptyContainer, { minHeight: minContentHeight }]}>
           <MaterialIcons
             name="dynamic-feed"
             size={48}

--- a/components/profile/profile-posts.tsx
+++ b/components/profile/profile-posts.tsx
@@ -1,0 +1,239 @@
+import { ThemedText } from "@/components/ui/themed-text";
+import FeedItemRouter from "@/components/ui/posts/feed-item-router";
+import { Colors } from "@/constants/theme";
+import { useTheme } from "@/contexts/ThemeContext";
+import feedApi, { FeedPost, FeedResponse } from "@/services/feedApi";
+import { MaterialIcons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import PostFilterChips, {
+  getPostTypeForFilter,
+  PostFilterType,
+} from "./post-filter-chips";
+
+const PAGE_SIZE = 20;
+
+interface ProfilePostsProps {
+  userId: number;
+  isOwnProfile: boolean;
+}
+
+export default function ProfilePosts({ userId, isOwnProfile }: ProfilePostsProps) {
+  const { colors } = useTheme();
+  const [posts, setPosts] = useState<FeedPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const [hasMore, setHasMore] = useState(true);
+  const [activeFilter, setActiveFilter] = useState<PostFilterType>("All");
+  const offsetRef = useRef(0);
+
+  const fetchPosts = useCallback(
+    async (offset: number = 0, isRefresh: boolean = false) => {
+      try {
+        const postType = getPostTypeForFilter(activeFilter);
+        const response: FeedResponse = await feedApi.getUserPosts(
+          userId,
+          PAGE_SIZE,
+          offset,
+          postType
+        );
+
+        if (isRefresh || offset === 0) {
+          setPosts(response.items);
+        } else {
+          setPosts((prev) => [...prev, ...response.items]);
+        }
+
+        offsetRef.current = offset + response.items.length;
+        setHasMore(response.items.length === PAGE_SIZE);
+      } catch (error) {
+        console.error("Failed to fetch user posts:", error);
+      }
+    },
+    [userId, activeFilter]
+  );
+
+  // Initial load & reload when filter changes
+  useEffect(() => {
+    setLoading(true);
+    offsetRef.current = 0;
+    fetchPosts(0, true).finally(() => setLoading(false));
+  }, [fetchPosts]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    await fetchPosts(offsetRef.current);
+    setLoadingMore(false);
+  }, [loadingMore, hasMore, fetchPosts]);
+
+  const handleDeletePost = useCallback((postId: number) => {
+    setPosts((prev) => prev.filter((p) => p.id !== postId));
+  }, []);
+
+  const handleFilterChange = useCallback((filter: PostFilterType) => {
+    setActiveFilter(filter);
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={Colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Filter Chips */}
+      <PostFilterChips
+        activeFilter={activeFilter}
+        onFilterChange={handleFilterChange}
+      />
+
+      {/* Posts Feed */}
+      {posts.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <MaterialIcons
+            name="dynamic-feed"
+            size={48}
+            color={colors.mutedForeground}
+          />
+          <ThemedText style={[styles.emptyTitle, { color: colors.text }]}>
+            No posts yet
+          </ThemedText>
+          <ThemedText
+            style={[styles.emptySubtitle, { color: colors.mutedForeground }]}
+          >
+            {isOwnProfile
+              ? "Share your favorite music to see it here"
+              : "This user hasn't posted anything yet"}
+          </ThemedText>
+          {isOwnProfile && (
+            <Pressable
+              style={[styles.ctaButton, { backgroundColor: Colors.primary }]}
+              onPress={() => router.push("/(tabs)/post")}
+            >
+              <ThemedText style={styles.ctaText}>Share something →</ThemedText>
+            </Pressable>
+          )}
+        </View>
+      ) : (
+        <View style={styles.feedContainer}>
+          {posts.map((post, index) => (
+            <Animated.View
+              key={post.id}
+              entering={FadeInDown.delay(Math.min(index * 50, 300))
+                .duration(400)
+                .springify()}
+              style={[
+                styles.postCard,
+                {
+                  backgroundColor:
+                    colors.background === "#18181B"
+                      ? "rgba(255,255,255,0.04)"
+                      : "rgba(0,0,0,0.03)",
+                  borderColor:
+                    colors.background === "#18181B"
+                      ? "rgba(255,255,255,0.08)"
+                      : "rgba(0,0,0,0.06)",
+                },
+              ]}
+            >
+              <FeedItemRouter item={post} onDelete={handleDeletePost} />
+            </Animated.View>
+          ))}
+
+          {/* Loading more indicator / Load more trigger */}
+          {loadingMore ? (
+            <View style={styles.loadingMoreContainer}>
+              <ActivityIndicator size="small" color={Colors.primary} />
+            </View>
+          ) : hasMore ? (
+            <Pressable style={styles.loadMoreButton} onPress={handleLoadMore}>
+              <ThemedText style={[styles.loadMoreText, { color: Colors.primary }]}>
+                Load more
+              </ThemedText>
+            </Pressable>
+          ) : null}
+
+          {/* Bottom spacer */}
+          <View style={styles.bottomSpacer} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingVertical: 60,
+  },
+  feedContainer: {
+    paddingHorizontal: 16,
+  },
+  postCard: {
+    borderRadius: 16,
+    borderWidth: 0.5,
+    padding: 12,
+    marginBottom: 12,
+    overflow: "hidden",
+  },
+  emptyContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 60,
+    paddingHorizontal: 32,
+    gap: 12,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    marginTop: 8,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  ctaButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 24,
+    marginTop: 8,
+  },
+  ctaText: {
+    color: "#FFFFFF",
+    fontWeight: "600",
+    fontSize: 15,
+  },
+  loadingMoreContainer: {
+    paddingVertical: 20,
+    alignItems: "center",
+  },
+  loadMoreButton: {
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  loadMoreText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  bottomSpacer: {
+    height: 40,
+  },
+});

--- a/components/profile/profile-posts.tsx
+++ b/components/profile/profile-posts.tsx
@@ -140,16 +140,6 @@ export default function ProfilePosts({ userId, isOwnProfile }: ProfilePostsProps
                 .springify()}
               style={[
                 styles.postCard,
-                {
-                  backgroundColor:
-                    colors.background === "#18181B"
-                      ? "rgba(255,255,255,0.04)"
-                      : "rgba(0,0,0,0.03)",
-                  borderColor:
-                    colors.background === "#18181B"
-                      ? "rgba(255,255,255,0.08)"
-                      : "rgba(0,0,0,0.06)",
-                },
               ]}
             >
               <FeedItemRouter item={post} onDelete={handleDeletePost} />
@@ -192,7 +182,6 @@ const styles = StyleSheet.create({
   },
   postCard: {
     borderRadius: 16,
-    borderWidth: 0.5,
     padding: 12,
     marginBottom: 12,
     overflow: "hidden",

--- a/components/profile/profile-tab-bar.tsx
+++ b/components/profile/profile-tab-bar.tsx
@@ -1,0 +1,85 @@
+import { ThemedText } from "@/components/ui/themed-text";
+import { Colors } from "@/constants/theme";
+import { useTheme } from "@/contexts/ThemeContext";
+import { MaterialIcons } from "@expo/vector-icons";
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+
+export type ProfileTab = "activity" | "posts";
+
+interface ProfileTabBarProps {
+  activeTab: ProfileTab;
+  onTabChange: (tab: ProfileTab) => void;
+}
+
+const TABS: { key: ProfileTab; label: string; icon: keyof typeof MaterialIcons.glyphMap }[] = [
+  { key: "activity", label: "Activity", icon: "library-music" },
+  { key: "posts", label: "Posts", icon: "grid-view" },
+];
+
+export default function ProfileTabBar({ activeTab, onTabChange }: ProfileTabBarProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background, borderBottomColor: colors.border }]}>
+      {TABS.map((tab) => {
+        const isActive = activeTab === tab.key;
+        return (
+          <Pressable
+            key={tab.key}
+            style={[styles.tab]}
+            onPress={() => onTabChange(tab.key)}
+          >
+            <MaterialIcons
+              name={tab.icon}
+              size={20}
+              color={isActive ? Colors.primary : colors.mutedForeground}
+            />
+            <ThemedText
+              style={[
+                styles.tabLabel,
+                {
+                  color: isActive ? Colors.primary : colors.mutedForeground,
+                  fontWeight: isActive ? "700" : "500",
+                },
+              ]}
+            >
+              {tab.label}
+            </ThemedText>
+            {isActive && (
+              <View style={[styles.activeIndicator, { backgroundColor: Colors.primary }]} />
+            )}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    borderBottomWidth: 0.5,
+    paddingTop: 4,
+  },
+  tab: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 12,
+    gap: 4,
+    position: "relative",
+  },
+  tabLabel: {
+    fontSize: 13,
+    letterSpacing: 0.3,
+  },
+  activeIndicator: {
+    position: "absolute",
+    bottom: 0,
+    left: "20%",
+    right: "20%",
+    height: 2.5,
+    borderRadius: 2,
+  },
+});

--- a/components/profile/user-profile.tsx
+++ b/components/profile/user-profile.tsx
@@ -19,7 +19,9 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import CompatibilityScore from "./compatibility-score";
 import ProfileContent from "./profile-content";
 import ProfileHeader from "./profile-header";
+import ProfilePosts from "./profile-posts";
 import ProfileStats from "./profile-stats";
+import ProfileTabBar, { ProfileTab } from "./profile-tab-bar";
 import { ThemedText } from "@/components/ui/themed-text";
 
 const PAGE_SIZE = 50;
@@ -67,6 +69,7 @@ export default function UserProfile({ userId }: UserProfileProps) {
 
   const scrollViewRef = useRef<ScrollView>(null);
   const isOwnProfile = !userId;
+  const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
 
   // Use the shared content hook for data fetching
   const {
@@ -286,6 +289,7 @@ export default function UserProfile({ userId }: UserProfileProps) {
         bounces={true}
         scrollEventThrottle={400}
         onScrollBeginDrag={collapse}
+        stickyHeaderIndices={[1]}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
@@ -295,6 +299,7 @@ export default function UserProfile({ userId }: UserProfileProps) {
           />
         }
       >
+        {/* Section 0: Header (scrolls away) */}
         <View style={styles.headerContainer}>
           <ProfileHeader
             profileData={profileData}
@@ -311,42 +316,53 @@ export default function UserProfile({ userId }: UserProfileProps) {
             formatNumber={formatNumber}
             userId={effectiveUserId}
           />
+
+          {/* Compatibility Score — only on other users' profiles */}
+          {!isOwnProfile && (
+            <CompatibilityScore
+              compatibility={compatibility}
+              loading={compatibilityLoading}
+            />
+          )}
         </View>
 
-        {/* Compatibility Score — only on other users' profiles */}
-        {!isOwnProfile && (
-          <CompatibilityScore
-            compatibility={compatibility}
-            loading={compatibilityLoading}
+        {/* Section 1: Tab Bar (sticky) */}
+        <ProfileTabBar activeTab={activeTab} onTabChange={setActiveTab} />
+
+        {/* Section 2: Tab Content */}
+        {activeTab === "activity" ? (
+          <ProfileContent
+            loading={false}
+            contentLoading={contentLoading}
+            recentTracks={recentTracks}
+            likedTracks={likedTracks}
+            likedAlbums={likedAlbums}
+            playlists={playlists}
+            followedArtists={followedArtists}
+            isOwnProfile={isOwnProfile}
+            spotifyId={profileData?.spotifyId}
+            onLoadMoreLikedTracks={() => {
+              if (pagination.likedTracks.hasMore && !contentLoading.tracks) {
+                fetchLikedTracks(PAGE_SIZE, likedTracks.length);
+              }
+            }}
+            onLoadMoreLikedAlbums={() => {
+              if (pagination.likedAlbums.hasMore && !contentLoading.albums) {
+                fetchLikedAlbums(PAGE_SIZE, likedAlbums.length);
+              }
+            }}
+            onLoadMoreFollowedArtists={() => {
+              if (pagination.followedArtists.hasMore && !contentLoading.artists) {
+                fetchFollowedArtists(PAGE_SIZE, followedArtists.length);
+              }
+            }}
+          />
+        ) : (
+          <ProfilePosts
+            userId={effectiveUserId!}
+            isOwnProfile={isOwnProfile}
           />
         )}
-
-        <ProfileContent
-          loading={false}
-          contentLoading={contentLoading}
-          recentTracks={recentTracks}
-          likedTracks={likedTracks}
-          likedAlbums={likedAlbums}
-          playlists={playlists}
-          followedArtists={followedArtists}
-          isOwnProfile={isOwnProfile}
-          spotifyId={profileData?.spotifyId}
-          onLoadMoreLikedTracks={() => {
-            if (pagination.likedTracks.hasMore && !contentLoading.tracks) {
-              fetchLikedTracks(PAGE_SIZE, likedTracks.length);
-            }
-          }}
-          onLoadMoreLikedAlbums={() => {
-            if (pagination.likedAlbums.hasMore && !contentLoading.albums) {
-              fetchLikedAlbums(PAGE_SIZE, likedAlbums.length);
-            }
-          }}
-          onLoadMoreFollowedArtists={() => {
-            if (pagination.followedArtists.hasMore && !contentLoading.artists) {
-              fetchFollowedArtists(PAGE_SIZE, followedArtists.length);
-            }
-          }}
-        />
       </ScrollView>
       )}
     </View>

--- a/components/profile/user-profile.tsx
+++ b/components/profile/user-profile.tsx
@@ -70,6 +70,17 @@ export default function UserProfile({ userId }: UserProfileProps) {
   const scrollViewRef = useRef<ScrollView>(null);
   const isOwnProfile = !userId;
   const [activeTab, setActiveTab] = useState<ProfileTab>("activity");
+  const headerHeightRef = useRef(0);
+  const scrollOffsetRef = useRef(0);
+
+  const handleTabChange = useCallback((tab: ProfileTab) => {
+    setActiveTab(tab);
+    // If user has scrolled past the header, snap to the tab bar position
+    // so the view doesn't jump to top
+    if (scrollOffsetRef.current > headerHeightRef.current) {
+      scrollViewRef.current?.scrollTo({ y: headerHeightRef.current, animated: false });
+    }
+  }, []);
 
   // Use the shared content hook for data fetching
   const {
@@ -287,7 +298,8 @@ export default function UserProfile({ userId }: UserProfileProps) {
         style={styles.scrollView}
         showsVerticalScrollIndicator={false}
         bounces={true}
-        scrollEventThrottle={400}
+        scrollEventThrottle={16}
+        onScroll={(e) => { scrollOffsetRef.current = e.nativeEvent.contentOffset.y; }}
         onScrollBeginDrag={collapse}
         stickyHeaderIndices={[1]}
         refreshControl={
@@ -300,7 +312,10 @@ export default function UserProfile({ userId }: UserProfileProps) {
         }
       >
         {/* Section 0: Header (scrolls away) */}
-        <View style={styles.headerContainer}>
+        <View
+          style={styles.headerContainer}
+          onLayout={(e) => { headerHeightRef.current = e.nativeEvent.layout.height; }}
+        >
           <ProfileHeader
             profileData={profileData}
             isOwnProfile={isOwnProfile}
@@ -327,7 +342,7 @@ export default function UserProfile({ userId }: UserProfileProps) {
         </View>
 
         {/* Section 1: Tab Bar (sticky) */}
-        <ProfileTabBar activeTab={activeTab} onTabChange={setActiveTab} />
+        <ProfileTabBar activeTab={activeTab} onTabChange={handleTabChange} />
 
         {/* Section 2: Tab Content */}
         {activeTab === "activity" ? (


### PR DESCRIPTION
## Summary

Adds a dedicated **Posts** section to the user profile with a segmented tab bar (Activity / Posts), allowing users to browse any user's post history directly from their profile.

Closes #41

---

## Changes

### New Components

- **`components/profile/profile-tab-bar.tsx`** — Segmented tab bar with Activity and Posts tabs, using `MaterialIcons` icons and a themed active indicator. Designed to be sticky-pinned below the header.

- **`components/profile/post-filter-chips.tsx`** — Horizontally scrollable filter chips (All, Shared, Sessions, Likes, Reposts) that control the `type` parameter sent to `feedApi.getUserPosts()`. Active chip gets a filled `Colors.primary` background.

- **`components/profile/profile-posts.tsx`** — Full posts feed component featuring:
  - Paginated fetching via `feedApi.getUserPosts()` (20 posts/page)
  - Staggered `FadeInDown` entry animations via `react-native-reanimated`
  - Glassmorphic card backgrounds with subtle borders (dark/light mode aware)
  - Filter chips integration for post type filtering
  - Empty state with icon, message, and CTA button (own profile only)
  - Load more button for infinite scroll pagination
  - Post delete support via `FeedItemRouter`

### Modified Files

- **`components/profile/user-profile.tsx`** — Integrated `ProfileTabBar` and `ProfilePosts`:
  - Added `stickyHeaderIndices={[1]}` to pin the tab bar when scrolling
  - Moved `CompatibilityScore` inside the header section (above sticky bar)
  - Tab state switches between `ProfileContent` (Activity) and `ProfilePosts` (Posts)

- **`components/profile/index.ts`** — Added barrel exports for new components

### Backend

No backend changes needed — the existing `GET /api/feed/user/{userId}` endpoint already supports:
- `type` query parameter for filtering
- `limit`/`offset` pagination
- Visibility filtering (public/followers)
- Soft-delete exclusion

---

## Acceptance Criteria Addressed

- [x] Profile page has a segmented tab bar with Activity and Posts tabs
- [x] Tab bar is sticky and pins to the top when scrolling past the header
- [x] Posts tab displays user's posts in reverse chronological order using existing post card components
- [x] Posts feed supports pagination (20 posts per page) with load more
- [x] Filter chips allow filtering posts by type (All, Shared, Sessions, Likes, Reposts)
- [x] Cards have smooth staggered fade-in animations on load
- [x] Empty state is shown when user has no posts
- [x] Works for both own profile and viewing other users' profiles
- [x] Post interactions (like, repost, delete) still function correctly from profile context